### PR TITLE
Fix: code sample on private vcs feature page

### DIFF
--- a/features/private-vcs-packages.md
+++ b/features/private-vcs-packages.md
@@ -1,7 +1,7 @@
 # Private Composer Packages
 ## 
 
-1Private Packagist makes the code in your private repositories available for use with Composer.
+Private Packagist makes the code in your private repositories available for use with Composer.
 
 ## Where can Private Packagist get code from?
 Private Packagist can access private code in any Git, Mercurial or Subversion repository with SSH or HTTP Basic authentication. This includes code stored on any of the following systems:

--- a/features/private-vcs-packages.md
+++ b/features/private-vcs-packages.md
@@ -20,7 +20,8 @@ If you are using our GitHub synchronization we will list all your repositories a
 ## How do I use Private Packagist in Composer?
 Add the Private Packagist repository to your composer.json and require the packages by name as you are used to. If you already had private version control system repositories configured, you can remove them to speed up composer update.
 
-```
+<pre>
+<code>
 {
     "repositories": [
         <span class="strikethrough">{"type": "vcs", "url": "https://github.com/<i>your-org-name</i>/foo"},</span>
@@ -33,5 +34,6 @@ Add the Private Packagist repository to your composer.json and require the packa
         "org/bar": "dev-master"
     }
 }
-```
+</code>
+</pre>
 **Note:** Your composer.lock file contains the download URLs for packages. You need to run composer update at least once to regenerate your composer.lock file before composer install will download files from Private Packagist.


### PR DESCRIPTION

<img width="741" alt="Screenshot 2020-03-31 at 10 09 41" src="https://user-images.githubusercontent.com/442056/78008608-c1cc2b00-7337-11ea-8e11-ddf02800abb2.png">


Unfortunately you cannot use strikethrough inside code blocks in markdown