### PR TITLE
Fix repositories entry to disable packagist.org

### DIFF
--- a/features/private-vcs-packages.md
+++ b/features/private-vcs-packages.md
@@ -27,7 +27,7 @@ Add the Private Packagist repository to your composer.json and require the packa
         <span class="strikethrough">{"type": "vcs", "url": "https://github.com/<i>your-org-name</i>/foo"},</span>
         <span class="strikethrough">{"type": "git", "url": "https://github.com/<i>your-org-name</i>/bar.git"},</span>
         {"type": "composer", "url": "https://repo.packagist.com/<i>your-org-name</i>/"},
-        {"packagist.org": false}
+        "packagist": false
     ],
     "require": {
         "org/foo": "^1.2.3",

--- a/features/private-vcs-packages.md
+++ b/features/private-vcs-packages.md
@@ -23,12 +23,12 @@ Add the Private Packagist repository to your composer.json and require the packa
 <pre>
 <code>
 {
-    "repositories": [
-        <span class="strikethrough">{"type": "vcs", "url": "https://github.com/<i>your-org-name</i>/foo"},</span>
-        <span class="strikethrough">{"type": "git", "url": "https://github.com/<i>your-org-name</i>/bar.git"},</span>
-        {"type": "composer", "url": "https://repo.packagist.com/<i>your-org-name</i>/"},
+    "repositories": {
+        <span class="strikethrough">"foo": {"type": "vcs", "url": "https://github.com/<i>your-org-name</i>/foo"},</span>
+        <span class="strikethrough">"bar": {"type": "git", "url": "https://github.com/<i>your-org-name</i>/bar.git"},</span>
+        "your-org-name": {"type": "composer", "url": "https://repo.packagist.com/<i>your-org-name</i>/"},
         "packagist": false
-    ],
+    },
     "require": {
         "org/foo": "^1.2.3",
         "org/bar": "dev-master"


### PR DESCRIPTION
Composer has a build-in command to disable packagist.org - `composer config repo.packagist false`.
If you use this, then you will find in the configuration
`"packagist": false`
instead of 
`{"packagist.org": false}`

This is also more compatible with valdiators that check `composer.json`.
Note: `repositories` has to be an object, otherwise `"packagist": false` would not be valid.