### PR TITLE
Fix commands in migration guide

### DIFF
--- a/docs/self-hosted/kubernetes-migration-guide.md
+++ b/docs/self-hosted/kubernetes-migration-guide.md
@@ -3,7 +3,7 @@
 
 ## Requirements
 
-To start the migration process, your Private Packagist Self-Hosted Replicated Native instance needs to run version 1.12.5 or newer.
+To start the migration process, your Private Packagist Self-Hosted Replicated Native instance needs to run version 1.12.8 or newer.
 To reduce the disruption to a minimum, we recommend that you set up your Private Packagist Self-Hosted Kubernetes
 instance on a different machine before you start the migration process.
 

--- a/docs/self-hosted/kubernetes-migration-guide.md
+++ b/docs/self-hosted/kubernetes-migration-guide.md
@@ -138,7 +138,7 @@ kubectl scale statefulset redis --replicas 1
 Importing the dist and artifact files requires the UI pods to be back online. Start them with the command below. This will take a few seconds.
 You can use the second command to verify once 2/2 pods are running.
 ```
-kubectl scale statefulset ui --replicas 1
+kubectl scale deployment ui --replicas 1
 kubectl get pods -w
 ```
 
@@ -148,7 +148,7 @@ it can take several minutes for this command to finish.
 ```
 export UI_POD=$(kubectl get pods --no-headers -o custom-columns=":metadata.name"|grep ui-)
 kubectl cp packagist_storage.tar.gz $UI_POD:/tmp/packagist_storage.tar.gz -c ui
-kubectl exec $UI_POD -c ui -- /bin/sh -c "/srv/manager/bin/console packagist:self-hosted:migrate-storage import /tmp/packagist_storage.tar.gz && rm /tmp/packagist_storage.tar.gz" 
+kubectl exec $UI_POD -c ui -- /bin/sh -c "/srv/manager/bin/console packagist:self-hosted:migrate-storage import /tmp/packagist_storage.tar.gz && rm /tmp/packagist_storage.tar" 
 ```
 
 ### Start the Private Packagist application
@@ -156,7 +156,7 @@ kubectl exec $UI_POD -c ui -- /bin/sh -c "/srv/manager/bin/console packagist:sel
 Once your data has been restored. Start the application:
 
 ```
-kubectl scale deployment ui --replicas 1
+kubectl scale deployment ui repo worker --replicas 1
 ```
 
 This can take a few minutes. You can run the command below to see when all pods are back up and running.


### PR DESCRIPTION
Fixes two commands in migration guide. Also updates minimum required version to the current version we're about to release (1.12.8)