### PR TITLE
Add reverse-proxy troubleshooting section to Kubernetes docs

### DIFF
--- a/docs/self-hosted/kubernetes-troubleshooting.md
+++ b/docs/self-hosted/kubernetes-troubleshooting.md
@@ -46,8 +46,7 @@ Peer closed connection in SSL handshake (104: Connection reset by peer) while SS
 ```
 
 Ensure that the SNI (Server Name Indication) TLS Extension is properly passed in requests to the cluster
-for SNI to work correctly on the ingress. When using IPs as upstream hostnames on the reverse-proxy, this is not the case
-by default and will result in a certificate error.
+for SNI to work correctly on the ingress. This is not the case when using IPs in `proxy_pass` on the reverse proxy and will result in an SSL handshake error.
 
 To pass the SNI hostname from the incoming request to the upstream server, apply the following settings when using
 NGINX as a reverse-proxy:

--- a/docs/self-hosted/kubernetes-troubleshooting.md
+++ b/docs/self-hosted/kubernetes-troubleshooting.md
@@ -36,3 +36,27 @@ System.
 > a year. As Private Packagist only allows a time-drift of up to one (1) minute, we
 > recommend using TOTP devices that have the ability to stay synchronized with
 > the correct time (such as a phone, or re-programmable TOTP hardware devices).
+
+#### Issues with Reverse-Proxy running in front of the Kubernetes Cluster
+
+Please follow the instructions below, if you are experiencing problems with the reverse-proxy not being able to connect to
+the cluster and encountering errors like this:
+```
+Peer closed connection in SSL handshake (104: Connection reset by peer) while SSL handshaking to upstream
+```
+
+Ensure that the SNI (Server Name Indication) TLS Extension is properly passed in requests to the cluster
+for SNI to work correctly on the ingress. When using IPs as upstream hostnames on the reverse-proxy, this is not the case
+by default and will result in a certificate error.
+
+To pass the SNI hostname from the incoming request to the upstream server, apply the following settings when using
+NGINX as a reverse-proxy:
+``` 
+proxy_ssl_name $host;
+proxy_ssl_server_name on;
+```
+
+If you are using different hostnames on the upstream and on the reverse-proxy, set the value in the
+`proxy_ssl_name` directive to the corresponding hostname of the upstream server.
+
+Please consult the documentation of other reverse-proxy servers to achieve the same result.

--- a/docs/self-hosted/kubernetes-troubleshooting.md
+++ b/docs/self-hosted/kubernetes-troubleshooting.md
@@ -45,10 +45,13 @@ the cluster and encountering errors like this:
 Peer closed connection in SSL handshake (104: Connection reset by peer) while SSL handshaking to upstream
 ```
 
-Ensure that the SNI (Server Name Indication) TLS Extension is properly set for requests to the ingress controller of the Kubernetes Cluster.
-This is not the case when using IPs in `proxy_pass` on the reverse proxy and will result in an SSL handshake error.
+The following examples assume you are using nginx as a reverse-proxy. Please consult the documentation of other 
+reverse-proxy servers to achieve the same result.
 
-To pass the SNI hostname from the incoming request to the upstream server, add the following directives to NGINX:
+Ensure that the SNI (Server Name Indication) TLS Extension is properly set for requests to the ingress controller of the Kubernetes Cluster.
+This is not the case when using IPs in `proxy_pass` and will result in an SSL handshake error.
+
+To pass the SNI hostname from the incoming request to the upstream server, add the following directives to nginx:
 ``` 
 proxy_ssl_name $host;
 proxy_ssl_server_name on;
@@ -57,4 +60,4 @@ proxy_ssl_server_name on;
 If you are using different hostnames on the upstream and on the reverse-proxy, set the value in the
 `proxy_ssl_name` directive to the corresponding hostname of the upstream server.
 
-Please consult the documentation of other reverse-proxy servers to achieve the same result.
+

--- a/docs/self-hosted/kubernetes-troubleshooting.md
+++ b/docs/self-hosted/kubernetes-troubleshooting.md
@@ -48,8 +48,7 @@ Peer closed connection in SSL handshake (104: Connection reset by peer) while SS
 Ensure that the SNI (Server Name Indication) TLS Extension is properly passed in requests to the cluster
 for SNI to work correctly on the ingress. This is not the case when using IPs in `proxy_pass` on the reverse proxy and will result in an SSL handshake error.
 
-To pass the SNI hostname from the incoming request to the upstream server, apply the following settings when using
-NGINX as a reverse-proxy:
+To pass the SNI hostname from the incoming request to the upstream server, add the following directives to NGINX:
 ``` 
 proxy_ssl_name $host;
 proxy_ssl_server_name on;

--- a/docs/self-hosted/kubernetes-troubleshooting.md
+++ b/docs/self-hosted/kubernetes-troubleshooting.md
@@ -45,8 +45,8 @@ the cluster and encountering errors like this:
 Peer closed connection in SSL handshake (104: Connection reset by peer) while SSL handshaking to upstream
 ```
 
-Ensure that the SNI (Server Name Indication) TLS Extension is properly passed in requests to the cluster
-for SNI to work correctly on the ingress. This is not the case when using IPs in `proxy_pass` on the reverse proxy and will result in an SSL handshake error.
+Ensure that the SNI (Server Name Indication) TLS Extension is properly set for requests to the ingress controller of the Kubernetes Cluster.
+This is not the case when using IPs in `proxy_pass` on the reverse proxy and will result in an SSL handshake error.
 
 To pass the SNI hostname from the incoming request to the upstream server, add the following directives to NGINX:
 ``` 


### PR DESCRIPTION
Will look like this:
<img width="942" alt="ScreenFloat Bildschirmfoto von Google Chrome am 14_11_2024, 16_50_21" src="https://github.com/user-attachments/assets/d7db7287-7e0f-406c-a5d9-c8941c621164">

I also mentioned another possible issue if they are using different hostnames on their internal network for the upstream just to be sure.