### PR TITLE
Kubernetes: update domain list for firewall config

### DIFF
--- a/docs/self-hosted/kubernetes-embedded.md
+++ b/docs/self-hosted/kubernetes-embedded.md
@@ -24,14 +24,19 @@ in an existing Kubernetes cluster using Helm follow [this guide](./kubernetes-he
     * Ports 80, 443, and 8800 must be accessible, for a full list of ports
     * Must be reachable at the chosen domain names from your local machine
 1. If your firewall restricts external connections the following domains must be accessible from the server:
-  * hub.docker.com
-  * proxy.replicated.com
+  * index.docker.io
+  * cdn.auth0.com
+  * *.docker.io
+  * *.docker.com
   * replicated.app
-  * amazonaws.com
-  * k8s.gcr.io
-  * k8s.kurl.sh (required to install the kots CLI)
+  * proxy.replicated.com
+  * registry.replicated.com
   * kots.io (required to install the kots CLI)
   * github.com (required to install the kots CLI)
+  * k8s.kurl.sh (required to install the kots CLI)
+  * s3.kurl.sh (required to install the kots CLI)
+  * amazonaws.com (required to install the kots CLI)
+
 <!-- See https://docs.replicated.com/enterprise/installing-general-requirements and https://kurl.sh/docs/install-with-kurl/system-requirements -->
 
 ## Installation

--- a/docs/self-hosted/kubernetes-helm.md
+++ b/docs/self-hosted/kubernetes-helm.md
@@ -13,12 +13,13 @@ to instead install Private Packagist Self-Hosted without an existing Kubernetes 
 1. An SSL certificate valid for both chosen domains
 1. An SMTP server or a GMail account for Private Packagist Self-Hosted to send email
 1. If your firewall restricts external connections then the following domains must be accessible from the server:
-  * hub.docker.com
+  * index.docker.io
+  * cdn.auth0.com
+  * *.docker.io
+  * *.docker.com
+  * replicated.app
   * proxy.replicated.com
   * registry.replicated.com
-  * replicated.app
-  * amazonaws.com
-  * k8s.gcr.io
 
 ## Installation
 


### PR DESCRIPTION
I reordered the domain to match the list on the Replicated docs based off https://docs.replicated.com/enterprise/installing-general-requirements#firewall-openings-for-online-installations