### PR TITLE
Add an alternative approach to create a migration package

### DIFF
--- a/docs/self-hosted/kubernetes-migration-guide.md
+++ b/docs/self-hosted/kubernetes-migration-guide.md
@@ -42,6 +42,22 @@ docker exec -it packagist-ui rm /tmp/storage.tar.gz
 docker stop packagist-ui
 ```
 
+In case you run into timeout problems while running the `migrate-storage` command, we offer an alternative approach
+using only the `tar` command.
+
+```
+# The following commands may require root permissions
+docker stop packagist-ui
+cd /data/packagist
+
+# Ensure all needed folders are present
+mkdir -p artifacts composer
+
+# Replace YOUR_BACKUP_PATH with the path you wish to save the backup to
+tar -cvzf YOUR_BACKUP_PATH/packagist_storage.tar.gz --transform s/^composer/dist/ --transform s/^artifacts/artifact/ composer artifacts
+```
+
+
 ### Backup the PostgreSQL database
 
 At the end of this step, you should have a `packagist_db.sql` file in your working directory.


### PR DESCRIPTION
When importing the migration tar archive we expect there to be two folders: `dist` and `artifact`

That's why the `composer` folder must be renamed to `dist` and `artifacts` folder to `artifact`.

@glaubinix the only thing I don't quite understand is that the `SelfHostedStorageMigrationCommand` is also expecting these two folders on the source system - at least when using FlySystem/S3. I presume there is some logic somewhere that maps composer and artifacts folders in local FS accordingly, but couldn't find that. Please let me know if I'm missing something here.