### PR TITLE
Clarify that multi-node setup can't be used with built-in services

### DIFF
--- a/docs/self-hosted/kubernetes-embedded.md
+++ b/docs/self-hosted/kubernetes-embedded.md
@@ -37,7 +37,7 @@ in an existing Kubernetes cluster using Helm follow [this guide](./kubernetes-he
   * s3.kurl.sh (required to install the kots CLI)
   * amazonaws.com (required to install the kots CLI)
 
-> Please note that a multi-node setup with kURL is only possible if no built-in services (postgres, minio, redis) are used.
+> Please note that the built-in services (PostgreSQL, MinIO, Redis) are meant to be used with a single-node setup only, because these options rely on local file storage.
 > Consult the documentation of your Cloud Provider what managed services can replace the built-in services 
 > (eg. for AWS RDS, S3 and ElastiCache)
 

--- a/docs/self-hosted/kubernetes-embedded.md
+++ b/docs/self-hosted/kubernetes-embedded.md
@@ -37,9 +37,6 @@ in an existing Kubernetes cluster using Helm follow [this guide](./kubernetes-he
   * s3.kurl.sh (required to install the kots CLI)
   * amazonaws.com (required to install the kots CLI)
 
-> Please note that the built-in services (PostgreSQL, MinIO, Redis) are meant to be used with a single-node setup only, because these options rely on local file storage.
-> Consult the documentation of your Cloud Provider what managed services can replace the built-in services 
-> (eg. for AWS RDS, S3 and ElastiCache)
 
 
 <!-- See https://docs.replicated.com/enterprise/installing-general-requirements and https://kurl.sh/docs/install-with-kurl/system-requirements -->
@@ -87,6 +84,11 @@ you can download it from https://packagist.com.
 ![Upload License](/Resources/public/img/docs/self-hosted-kubernetes/console-license.png)
 
 #### Configure Private Packagist Self-Hosted
+
+> Please note that the built-in services (PostgreSQL, MinIO, Redis) are meant to be used with a single-node setup only, because these options rely on local file storage.
+> Consult the documentation of your Cloud Provider what managed services can replace the built-in services
+> (eg. for AWS RDS, S3 and ElastiCache)
+
 The configuration screen is where you can set up the domains used for Private Packagist and the email configuration. It
 is also the place where you can configure if Private Packagist should use an existing Redis, PostgreSQL, or blob storage.
 ![Configuration](/Resources/public/img/docs/self-hosted-kubernetes/console-configure-application.png)

--- a/docs/self-hosted/kubernetes-embedded.md
+++ b/docs/self-hosted/kubernetes-embedded.md
@@ -37,6 +37,11 @@ in an existing Kubernetes cluster using Helm follow [this guide](./kubernetes-he
   * s3.kurl.sh (required to install the kots CLI)
   * amazonaws.com (required to install the kots CLI)
 
+> Please note that a multi-node setup with kURL is only possible if no built-in services (postgres, minio, redis) are used.
+> Consult the documentation of your Cloud Provider what managed services can replace the built-in services 
+> (eg. for AWS RDS, S3 and ElastiCache)
+
+
 <!-- See https://docs.replicated.com/enterprise/installing-general-requirements and https://kurl.sh/docs/install-with-kurl/system-requirements -->
 
 ## Installation


### PR DESCRIPTION
Trello Ticket: https://trello.com/c/u1EO0thW/4525-self-hosted-clarify-in-the-docs-that-multi-node-setup-with-kurl-is-only-possible-if-no-built-in-services-are-used