### PR TITLE
Describe how to restore the ability to upload new TLS certificates

### DIFF
--- a/docs/self-hosted/kubernetes-maintenance.md
+++ b/docs/self-hosted/kubernetes-maintenance.md
@@ -35,6 +35,6 @@ Replace `NAMESPACE` with the namespace in your cluster where KOTS is installed.
 
 The following applies only to kURL installations. To update or replace the certificate, you must first restore the ability 
 to upload new TLS certificates and then reupload the certificate through the user interface. Please refer to 
-the [Replicated Documentation](https://docs.replicated.com/enterprise/updating-tls-cert#update-custom-tls-certificates) 
+the [Replicated documentation](https://docs.replicated.com/enterprise/updating-tls-cert#update-custom-tls-certificates) 
 for detailed instructions.
 

--- a/docs/self-hosted/kubernetes-maintenance.md
+++ b/docs/self-hosted/kubernetes-maintenance.md
@@ -31,7 +31,7 @@ kubectl kots admin-console upgrade -n NAMESPACE
 
 Replace `NAMESPACE` with the namespace in your cluster where KOTS is installed.
 
-### Updating or Replacing the SSL Certificate
+### Update or replace the SSL certificate
 
 The following applies only to kURL installations. To update or replace the certificate, you must first restore the ability 
 to upload new TLS certificates and then reupload the certificate through the user interface. Please refer to 

--- a/docs/self-hosted/kubernetes-maintenance.md
+++ b/docs/self-hosted/kubernetes-maintenance.md
@@ -31,3 +31,10 @@ kubectl kots admin-console upgrade -n NAMESPACE
 
 Replace `NAMESPACE` with the namespace in your cluster where KOTS is installed.
 
+### Updating or Replacing the SSL Certificate
+
+The following applies only to kURL installations. To update or replace the certificate, you must first restore the ability 
+to upload new TLS certificates and then reupload the certificate through the user interface. Please refer to 
+the [Replicated Documentation](https://docs.replicated.com/enterprise/updating-tls-cert#update-custom-tls-certificates) 
+for detailed instructions.
+

--- a/docs/self-hosted/kubernetes-maintenance.md
+++ b/docs/self-hosted/kubernetes-maintenance.md
@@ -33,8 +33,8 @@ Replace `NAMESPACE` with the namespace in your cluster where KOTS is installed.
 
 ### Update or replace the SSL certificate
 
-The following applies only to kURL installations. To update or replace the certificate, you must first restore the ability 
-to upload new TLS certificates and then reupload the certificate through the user interface. Please refer to 
-the [Replicated documentation](https://docs.replicated.com/enterprise/updating-tls-cert#update-custom-tls-certificates) 
+To update or replace the certificate, you must first restore the ability to upload new TLS certificates and then reupload 
+the certificate through the user interface. Please refer to the 
+[Replicated documentation](https://docs.replicated.com/enterprise/updating-tls-cert#update-custom-tls-certificates) 
 for detailed instructions.
 

--- a/docs/self-hosted/maintenance.md
+++ b/docs/self-hosted/maintenance.md
@@ -31,9 +31,6 @@ Go back to the dashboard on the Replicated Management Console and restart the ap
 
 If your certificate requires intermediate certificates to be recognized by your browser and/or Composer you can paste them into your certificate text file. Please make sure they are sorted from leaf (your certificate) via intermediate certificate to root certificate at the bottom. Otherwise Replicated will not recognize the certificate in a combined file.
 
-> In order to replace the certificate, you will first need to restore the ability to upload new TLS certificates as described in the 
-> [Replicated Documentation](https://docs.replicated.com/enterprise/updating-tls-cert#update-custom-tls-certificates)
-
 Please see the [Troubleshooting](./troubleshooting.md) page for details on dealing with SSL errors.
 
 #### Automating the replacement of the SSL certificate

--- a/docs/self-hosted/maintenance.md
+++ b/docs/self-hosted/maintenance.md
@@ -22,7 +22,7 @@ If your firewall restricts external connections the following domains must be ac
 
 REPLICATED_DOMAIN_LIST
    
-### Updating or Replacing the SSL Certificate
+### Update or replace the SSL certificate
 If you would like to upload a new SSL certificate or if you would like to reload an existing SSL certification from the host filesystem please open the Replicated Management Console at port 8800.
 Then open the settings menu with the gear icon on the top right and select "Console Settings". Scroll to "TLS Key & Cert" or click on the respective option in the menu. Here you can select a new certificate.
 Save the page to apply the new certificate to the Replicated Management Console. If you are using a server path and replaced the SSL certificate without changing the path, save the page to reload the certificate.

--- a/docs/self-hosted/maintenance.md
+++ b/docs/self-hosted/maintenance.md
@@ -31,6 +31,9 @@ Go back to the dashboard on the Replicated Management Console and restart the ap
 
 If your certificate requires intermediate certificates to be recognized by your browser and/or Composer you can paste them into your certificate text file. Please make sure they are sorted from leaf (your certificate) via intermediate certificate to root certificate at the bottom. Otherwise Replicated will not recognize the certificate in a combined file.
 
+> In order to replace the certificate, you will first need to restore the ability to upload new TLS certificates as described in the 
+> [Replicated Documentation](https://docs.replicated.com/enterprise/updating-tls-cert#update-custom-tls-certificates)
+
 Please see the [Troubleshooting](./troubleshooting.md) page for details on dealing with SSL errors.
 
 #### Automating the replacement of the SSL certificate


### PR DESCRIPTION
Trello ticket: https://trello.com/c/qNX6XNOY/4528-self-hosted-maintenance-docs-need-to-link-to-replicated-guide-to-change-ssl-certificate