### PR TITLE
Take into account multiple ways of redis persistence and ensure import is being done on the running UI pod.

### DIFF
--- a/docs/self-hosted/kubernetes-migration-guide.md
+++ b/docs/self-hosted/kubernetes-migration-guide.md
@@ -144,8 +144,9 @@ After each scale command, use `kubectl get pods` again to verify that the redis 
 ```
 export PV_NAME=$(kubectl get pvc redis-data-redis-0 -ojsonpath='{.spec.volumeName}')
 kubectl scale statefulset -n default redis --replicas 0
-rm /var/openebs/local/$PV_NAME/appendonly.aof
-cp packagist_redis.rdb /var/openebs/local/$PV_NAME/dump.rdb
+sudo rm -f /var/openebs/local/$PV_NAME/appendonly.aof
+sudo rm -rf /var/openebs/local/$PV_NAME/appendonlydir
+sudo cp packagist_redis.rdb /var/openebs/local/$PV_NAME/dump.rdb
 kubectl scale statefulset redis --replicas 1
 ```
 
@@ -162,7 +163,7 @@ Please note that depending on the size of the `packagist_storage.tar.gz` file an
 it can take several minutes for this command to finish.
 
 ```
-export UI_POD=$(kubectl get pods --no-headers -o custom-columns=":metadata.name"|grep ui-)
+export UI_POD=$(kubectl get pods --field-selector=status.phase=Running --no-headers -o custom-columns=":metadata.name"|grep ui-)
 kubectl cp packagist_storage.tar.gz $UI_POD:/tmp/packagist_storage.tar.gz -c ui
 kubectl exec $UI_POD -c ui -- /bin/sh -c "/srv/manager/bin/console packagist:self-hosted:migrate-storage import /tmp/packagist_storage.tar.gz && rm /tmp/packagist_storage.tar" 
 ```

--- a/docs/self-hosted/kubernetes-migration-guide.md
+++ b/docs/self-hosted/kubernetes-migration-guide.md
@@ -144,9 +144,10 @@ After each scale command, use `kubectl get pods` again to verify that the redis 
 ```
 export PV_NAME=$(kubectl get pvc redis-data-redis-0 -ojsonpath='{.spec.volumeName}')
 kubectl scale statefulset -n default redis --replicas 0
-sudo rm -f /var/openebs/local/$PV_NAME/appendonly.aof
-sudo rm -rf /var/openebs/local/$PV_NAME/appendonlydir
-sudo cp packagist_redis.rdb /var/openebs/local/$PV_NAME/dump.rdb
+# Depending on your setup, you might need to run the following three commands as `root`
+rm -f /var/openebs/local/$PV_NAME/appendonly.aof
+rm -rf /var/openebs/local/$PV_NAME/appendonlydir
+cp packagist_redis.rdb /var/openebs/local/$PV_NAME/dump.rdb
 kubectl scale statefulset redis --replicas 1
 ```
 


### PR DESCRIPTION
Trello Ticket: https://trello.com/c/w6Pj1IpF/4549-look-into-this-selfhosted-issues-while-migration-if-this-is-something-we-need-to-fix

Redis has multiple ways of persisting data on FS: https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/
It can be a single .aof file or a combination of RDB+AOF. To ensure that we properly cleanup data for both cases, I left both commands in, but with the `-f` flag to ensure that there are no errors if either path doesn't exist. 

NOTE: not sure about adding `sudo`. It was needed for these commands in my case. Should we leave that in or rather remove it and the user must figure that out? 

Regarding the second issue in the Trello ticket, we can see that multiple pod names have been assigned to the `UI_POD` variable. I presume that other ones were just leftover pods of failed deployments. I added a filter to the command to ensure that only the running UI pod is assigned. 