### PR TITLE
Update GitLab and GitHub self-hosted product names

### DIFF
--- a/docs/cloud/gitlab-integration-setup.md
+++ b/docs/cloud/gitlab-integration-setup.md
@@ -1,4 +1,4 @@
-# GitLab (Self-Managed) Integration Setup
+# GitLab Self-Managed Integration Setup
 ## Private Packagist Cloud
 
 <div class="row column">

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,4 +1,4 @@
-# Using Private Packagist in a Composer project
+# Composer Project Setup
 
 You can use Private Packagist in a new or in an existing Composer project. Some of the steps in this guide will only apply if your project needs the respective Composer feature explained in that step.
 

--- a/features/integration-github-bitbucket-gitlab.md
+++ b/features/integration-github-bitbucket-gitlab.md
@@ -26,7 +26,7 @@ Private Packagist integrates with the following systems:
 * Code Credentials: GitHub App or GitHub API Token
 * Webhooks: Code changes, releases, created repositories, team creation or member changes
 
-#### GitHub Enterprise
+#### GitHub Enterprise Server
 * OAuth: Users authenticate on Private Packagist with their GitHub accounts. Follow [this setup](../docs/cloud/github-integration-setup.md) for Cloud plans or [this setup](../docs/self-hosted/github-integration-setup.md) for Self-Hosted.
 * Synchronization:
     * Keeps team members and access permissions in sync with your GitHub Enterprise organizations
@@ -57,7 +57,7 @@ Private Packagist integrates with the following systems:
 * Code Credentials: GitLab API token
 * Webhooks: Code changes and releases
 
-#### GitLab (Self-hosted)
+#### GitLab Self-Managed
 * OAuth: Users authenticate on Private Packagist with their GitLab accounts. Follow [this setup](../docs/cloud/gitlab-integration-setup.md) for Cloud plans or [this setup](../docs/self-hosted/gitlab-integration-setup.md) for Self-Hosted.
 * Synchronization:
     * Keeps teams, their members, and access permissions in sync with your GitLab groups

--- a/features/private-vcs-packages.md
+++ b/features/private-vcs-packages.md
@@ -8,7 +8,7 @@ Private Packagist can access private code in any Git, Mercurial or Subversion re
 * GitHub
 * GitHub Enterprise
 * GitLab.com
-* GitLab (Self-hosted)
+* GitLab Self-Managed
 * Bitbucket.org / Cloud
 * Bitbucket Data Center / Server
 


### PR DESCRIPTION
This PR updates the GitLab and GitHub self-hosted product names.