### PR TITLE
Conductor: explain `COMPOSER_SKIP_SCRIPTS` 

### DIFF
--- a/docs/conductor/getting-started.md
+++ b/docs/conductor/getting-started.md
@@ -55,7 +55,7 @@ For example, if you use `npm` to build static assets when the `post-install-cmd`
 ```
 
 Please note that this feature is only available since [Composer 2.8.6](https://github.com/composer/composer/releases/tag/2.8.6), so make sure your CI 
-install the latest version.
+installs the latest version.
 
 ## Verify your CI setup
 

--- a/docs/conductor/getting-started.md
+++ b/docs/conductor/getting-started.md
@@ -40,6 +40,23 @@ Similar to organization authentication tokens, access can be restricted to any s
 
 Once the workflow is added to your GitHub repository, Conductor needs to verify your CI setup before you can start receiving PRs.
 
+### Skip Composer scripts
+
+If you've configured Composer to run scripts for certain events that make changes which are irrelevant for the Conductor PR, you can skip 
+these script handlers by setting the [COMPOSER_SKIP_SCRIPTS](https://getcomposer.org/doc/03-cli.md#composer-skip-scripts) environment variable.
+
+For example, if you use `npm` to build static assets when the `post-install-cmd` command event is triggered, update your GitHub action like this:
+
+```yaml
+- name: "Running Conductor"
+  uses: packagist/conductor-github-action@v1
+  env:
+    COMPOSER_SKIP_SCRIPTS: "post-install-cmd"
+```
+
+Please note that this feature is only available since [Composer 2.8.6](https://github.com/composer/composer/releases/tag/2.8.6), so make sure your CI 
+install the latest version.
+
 ## Verify your CI setup
 
 - Navigate to the "Conductor" tab in your Private Packagist organization.

--- a/docs/conductor/getting-started.md
+++ b/docs/conductor/getting-started.md
@@ -45,7 +45,7 @@ Once the workflow is added to your GitHub repository, Conductor needs to verify 
 If you've configured Composer to run scripts for certain events that make changes which are irrelevant for the Conductor PR, you can skip 
 these script handlers by setting the [COMPOSER_SKIP_SCRIPTS](https://getcomposer.org/doc/03-cli.md#composer-skip-scripts) environment variable.
 
-For example, if you use `npm` to build static assets when the `post-install-cmd` command event is triggered, update your GitHub action like this:
+For example, if you use `npm` to build static assets in your `post-install-cmd` script you can update your GitHub action to skip it:
 
 ```yaml
 - name: "Running Conductor"


### PR DESCRIPTION
Explains how to disable script handlers in Conductor with `COMPOSER_SKIP_SCRIPTS`