### PR TITLE
Bitbucket: suggest API Tokens only

### DIFF
--- a/docs/synchronizations-faq.md
+++ b/docs/synchronizations-faq.md
@@ -49,7 +49,7 @@ To make sure members can access the packages from all synchronizations from mult
 ### Bitbucket Cloud (bitbucket.org)
 * Synchronization:
     * Keeps groups, their members, and access permissions in sync with your Bitbucket workspace
-* Code Credentials: Bitbucket API Key or Bitbucket App Password
+* Code Credentials: Bitbucket API Token
 * Webhooks: Code changes and releases
 
 ### Bitbucket Data Center / Server

--- a/features/integration-github-bitbucket-gitlab.md
+++ b/features/integration-github-bitbucket-gitlab.md
@@ -29,7 +29,7 @@ Private Packagist integrates with the following systems:
 * OAuth: Users authenticate on Private Packagist with their Bitbucket accounts. If you use Private Packagist Self-Hosted, first create a Bitbucket app by following these [steps](../docs/self-hosted/bitbucket-integration-setup.md).
 * Synchronization:
     * Keeps groups, their members, and access permissions in sync with your Bitbucket workspace
-* Code Credentials: Bitbucket API Key or Bitbucket App Password
+* Code Credentials: Bitbucket API Token
 * Webhooks: Code changes and releases
 
 #### Bitbucket Data Center / Server


### PR DESCRIPTION
Only mention API Tokens now that App Passwords and API Keys are deprecated